### PR TITLE
Properly escape values in output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
+## 2.0.3
+ - Escape rogue values by default, which can be interpreted by spreadsheet apps. Add option to turn it off 
+
 ## 2.0.0
- - Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully, 
+ - Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully,
    instead of using Thread.raise on the plugins' threads. Ref: https://github.com/elastic/logstash/pull/3895
  - Dependency on logstash-core update to 2.0
-

--- a/lib/logstash/outputs/csv.rb
+++ b/lib/logstash/outputs/csv.rb
@@ -52,6 +52,6 @@ class LogStash::Outputs::CSV < LogStash::Outputs::File
 
   private
   def escape_csv(val)
-    spreadsheet_safe && val.is_a?(String) && val.start_with?("=") ? "'#{val}" : val
+    (spreadsheet_safe && val.is_a?(String) && val.start_with?("=")) ? "'#{val}" : val
   end
 end # class LogStash::Outputs::CSV

--- a/lib/logstash/outputs/csv.rb
+++ b/lib/logstash/outputs/csv.rb
@@ -23,7 +23,7 @@ class LogStash::Outputs::CSV < LogStash::Outputs::File
   # A typical use case would be to use alternative column or row seperators eg: `csv_options => {"col_sep" => "\t" "row_sep" => "\r\n"}` gives tab seperated data with windows line endings
   config :csv_options, :validate => :hash, :required => false, :default => Hash.new
   # Option to not escape/munge string values. Please note turning off this option
-  # may not be safe in your spreadsheet application
+  # may not make the values safe in your spreadsheet application
   config :spreadsheet_safe, :validate => :boolean, :default => true
 
   public

--- a/lib/logstash/outputs/csv.rb
+++ b/lib/logstash/outputs/csv.rb
@@ -22,6 +22,9 @@ class LogStash::Outputs::CSV < LogStash::Outputs::File
   # Full documentation is available on the http://ruby-doc.org/stdlib-2.0.0/libdoc/csv/rdoc/index.html[Ruby CSV documentation page].
   # A typical use case would be to use alternative column or row seperators eg: `csv_options => {"col_sep" => "\t" "row_sep" => "\r\n"}` gives tab seperated data with windows line endings
   config :csv_options, :validate => :hash, :required => false, :default => Hash.new
+  # Option to not escape/munge string values. Please note turning off this option
+  # may not be safe in your spreadsheet application
+  config :spreadsheet_safe, :validate => :boolean, :default => true
 
   public
   def register
@@ -49,6 +52,6 @@ class LogStash::Outputs::CSV < LogStash::Outputs::File
 
   private
   def escape_csv(val)
-    val.is_a?(String) && val.start_with?("=") ? "'#{val}" : val
+    spreadsheet_safe && val.is_a?(String) && val.start_with?("=") ? "'#{val}" : val
   end
 end # class LogStash::Outputs::CSV

--- a/lib/logstash/outputs/csv.rb
+++ b/lib/logstash/outputs/csv.rb
@@ -31,7 +31,7 @@ class LogStash::Outputs::CSV < LogStash::Outputs::File
 
   public
   def receive(event)
-    
+
     path = event.sprintf(@path)
     fd = open(path)
     csv_values = @fields.map {|name| get_value(name, event)}
@@ -44,7 +44,11 @@ class LogStash::Outputs::CSV < LogStash::Outputs::File
   private
   def get_value(name, event)
     val = event[name]
-    val.is_a?(Hash) ? LogStash::Json.dump(val) : val
+    val.is_a?(Hash) ? LogStash::Json.dump(val) : escape_csv(val)
+  end
+
+  private
+  def escape_csv(val)
+    val.is_a?(String) && val.start_with?("=") ? "'#{val}" : val
   end
 end # class LogStash::Outputs::CSV
-

--- a/logstash-output-csv.gemspec
+++ b/logstash-output-csv.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-csv'
-  s.version         = '2.0.2'
+  s.version         = '2.0.3'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Write events to disk in CSV or other delimited format"
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"
@@ -22,8 +22,8 @@ Gem::Specification.new do |s|
   # Gem dependencies
   s.add_runtime_dependency "logstash-core", ">= 2.0.0.beta2", "< 3.0.0"
 
+  s.add_runtime_dependency 'logstash-input-generator'
   s.add_runtime_dependency 'logstash-output-file'
   s.add_runtime_dependency 'logstash-filter-json'
   s.add_development_dependency 'logstash-devutils'
 end
-

--- a/spec/outputs/csv_spec.rb
+++ b/spec/outputs/csv_spec.rb
@@ -288,5 +288,31 @@ describe LogStash::Outputs::CSV do
       insist {lines[0][1]} == "'=1+1"
     end
   end
-  
+
+  describe "can turn off escaping rogue values" do
+    tmpfile = Tempfile.new('logstash-spec-output-csv')
+    config <<-CONFIG
+      input {
+        generator {
+          add_field => ["foo","1+1", "baz", "=1+1"]
+          count => 1
+        }
+      }
+      output {
+        csv {
+          path => "#{tmpfile.path}"
+          spreadsheet_safe => false
+          fields => ["foo", "baz"]
+        }
+      }
+    CONFIG
+
+    agent do
+      lines = CSV.read(tmpfile.path)
+      insist {lines.count} == 1
+      insist {lines[0][0]} == "1+1"
+      insist {lines[0][1]} == "=1+1"
+    end
+  end
+
 end


### PR DESCRIPTION
There are some values which can be interpreted by spreadsheet
software, so we need to escape them

Fixes #4