### PR TITLE
To use output-csv plugin with logstash 5.x , the method received need to be remplaced by multi_receive_encoded method 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.3
+  - Method received not called in logstash 5.x in favor of the inherited multi_receive_encoded
+
 ## 3.0.2
   - Relax constraint on logstash-core-plugin-api to >= 1.60 <= 2.99
 

--- a/lib/logstash/outputs/csv.rb
+++ b/lib/logstash/outputs/csv.rb
@@ -33,16 +33,19 @@ class LogStash::Outputs::CSV < LogStash::Outputs::File
   end
 
   public
-  def receive(event)
+  def multi_receive_encoded(encoded)
+    
+    encoded.each do |event,data|
+      path = event.sprintf(@path)
+      fd = open(path)
+      csv_values = @fields.map {|name| get_value(name, event)}
+      fd.write(csv_values.to_csv(@csv_options))
 
-    path = event.sprintf(@path)
-    fd = open(path)
-    csv_values = @fields.map {|name| get_value(name, event)}
-    fd.write(csv_values.to_csv(@csv_options))
+      flush(fd)
+      close_stale_files
+    end
 
-    flush(fd)
-    close_stale_files
-  end #def receive
+  end # def mutil_receive_encoded
 
   private
   def get_value(name, event)

--- a/logstash-output-csv.gemspec
+++ b/logstash-output-csv.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-csv'
-  s.version         = '3.0.2'
+  s.version         = '3.0.3'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Write events to disk in CSV or other delimited format"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
In logstash 5.x  the method received is not longer called in favor of the inherited multi_receive_encoded method  (https://github.com/logstash-plugins/logstash-output-csv/issues/10)

Modifications: the method received was remplaced by multi_receive_encoded method

File csv.rb
- Method inherited multi_receive_encoded added 
- Method received deleted

File logstash-output-csv.gempspec
- Version number updated to 3.0.3

File CHANGELOG.md
- Version number updated to 3.0.3
