### PR TITLE
Updates handling of optional named parameters for JRuby 9.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.9
+ - Fix: updates syntax to JRuby 9.4 [#25](https://github.com/logstash-plugins/logstash-output-csv/pull/25)
+
 ## 3.0.8
   - Docs: Correct typos [#19](https://github.com/logstash-plugins/logstash-output-csv/pull/19) 
   - Docs: Fix formatting after code sample [#22](https://github.com/logstash-plugins/logstash-output-csv/pull/22)

--- a/lib/logstash/outputs/csv.rb
+++ b/lib/logstash/outputs/csv.rb
@@ -56,7 +56,7 @@ class LogStash::Outputs::CSV < LogStash::Outputs::File
 
   def event_to_csv(event)
     csv_values = @fields.map {|name| get_value(name, event)}
-    csv_values.to_csv(@csv_options)
+    csv_values.to_csv(**@csv_options)
   end
 
   def get_value(name, event)

--- a/logstash-output-csv.gemspec
+++ b/logstash-output-csv.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-csv'
-  s.version         = '3.0.8'
+  s.version         = '3.0.9'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Writes events to disk in a delimited format"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Fix dictionary definition passed into the spec methods, to be compliant with JRuby 9.4

## How to test
Same steps as https://github.com/logstash-plugins/logstash-filter-cidr/pull/26
